### PR TITLE
导航栏显示顺序

### DIFF
--- a/StarrySky/functions.php
+++ b/StarrySky/functions.php
@@ -100,7 +100,7 @@ function duNav(){
     $db = Typecho_Db::get();
     $query = $db->select()
 ->from('table.contents')
-->where('table.contents.type = ?', 'page')->order('cid',Typecho_Db::SORT_ASC);
+->where('table.contents.type = ?', 'page')->order('order',Typecho_Db::SORT_ASC);
     
     $arr =  $db->fetchAll($query);
     


### PR DESCRIPTION
由于typecho独立页面管理中有单独的系统定义字段“页面顺序”，导航栏排序应该依照该可配置字段而非独立页面id（按创建顺序排序）